### PR TITLE
Easier Access to Wrong Results

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+Language:        Cpp
+BasedOnStyle:  Google
+---
+Language: Proto
+BasedOnStyle: Google

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 ## File Based Test Driver
 
-## Build
-
-File Based Test Driver uses [bazel](https://bazel.build) for building and
-dependency resolution. After installing bazel (we maintain support for 1.0,
-but other versions may work), simply run:
-
-```bazel build ...```
-
 ## Overview
 
 file_based_test_driver
@@ -15,13 +7,13 @@ uses `.test` files to specify sets of inputs and expected outputs. The format
 of these files is documented in `file_based_test_driver.h`.
 
 A detailed example that shows all features is in
-[`example.test`](example.test) and the associated test driver
-[`example_test.cc`](example_test.cc).
+[`example.test`](file_based_test_driver/example.test) and the associated test driver
+[`example_test.cc`](file_based_test_driver/example_test.cc).
 
 #### Test output with modes
 
 file_based_test_driver's basic test runner
-[RunTestCasesFromFiles](file_based_test_driver.h)
+[RunTestCasesFromFiles](file_based_test_driver/file_based_test_driver.h)
 calls a callback to run a test, gets back the actual outputs, and does string
 comparison on the actual and expected outputs. In some cases, the test callback
 may run a test case multiple times in different modes and each mode may generate
@@ -35,10 +27,10 @@ that understands test modes. The format of the test file is very similar to the
 one that is used with the basic test runner. Each test still has an input block
 followed by multiple output blocks. The only difference is that the output
 blocks of a test must be parsable by
-[`test_case_outputs.h`](test_case_outputs.h).
+[`test_case_outputs.h`](file_based_test_driver/test_case_outputs.h).
 The text format of such test output and its internal representation is
 documented in
-[`test_case_outputs.h`](test_case_outputs.h).
+[`test_case_outputs.h`](file_based_test_driver/test_case_outputs.h).
 The new test runner will first parse the expected output and group the outputs
 by test modes. It then calls the test callback and gets back the actual outputs
 for one or more modes, merges them into the expected outputs (only the outputs
@@ -46,10 +38,10 @@ for the modes tested are replaced), and compares the merged results with the
 expected results.
 
 Example that shows the test mode related features is in
-[`example_with_modes.test`](example_with_modes.test)
+[`example_with_modes.test`](file_based_test_driver/example_with_modes.test)
 and
 the associated test driver
-[`example_test_with_modes.cc`](example_test_with_modes.cc).
+[`example_test_with_modes.cc`](file_based_test_driver/example_test_with_modes.cc).
 
 ## Contributions
 

--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -16,7 +16,7 @@
 #include "file_based_test_driver/alternations.h"
 
 #include "absl/strings/str_join.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 
 namespace file_based_test_driver {
@@ -102,8 +102,8 @@ absl::Status AlternationSetWithModes::Record(
     const std::string& alternation_name,
     const RunTestCaseWithModesResult& test_case_result) {
   FILE_BASED_TEST_DRIVER_RET_CHECK(!finished_);
-  static LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
-  FILE_BASED_TEST_DRIVER_RET_CHECK(!RE2::PartialMatch(alternation_name, *re))
+  static re2_st::LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
+  FILE_BASED_TEST_DRIVER_RET_CHECK(!re2_st::RE2::PartialMatch(alternation_name, *re))
       << "Alternation \"" << alternation_name << "\" contains names that can't "
       << "be stored in a result_type: " << re->pattern();
   alternations_.emplace_back(

--- a/file_based_test_driver/base/logging.cc
+++ b/file_based_test_driver/base/logging.cc
@@ -253,8 +253,6 @@ void LogMessage::SendToLog(const std::string &message_text) {
     fprintf(stderr, "%s\n", message_text.c_str());
     fflush(stderr);
   }
-  printf("%s\n", message_text.c_str());
-  fflush(stdout);
 }
 
 void LogMessage::Flush() {

--- a/file_based_test_driver/base/source_location.h
+++ b/file_based_test_driver/base/source_location.h
@@ -133,7 +133,6 @@ class SourceLocation {
   std::uint_least32_t line_;
   std::uint_least32_t unused_column_ = 0;
   const char* file_name_;
-  const char* unused_function_name_ = nullptr;
 };
 
 }  // namespace file_based_test_driver_base

--- a/file_based_test_driver/base/status_macros.h
+++ b/file_based_test_driver/base/status_macros.h
@@ -189,10 +189,10 @@ class StatusAdaptorForMacros {
   StatusAdaptorForMacros(absl::Status&& status, SourceLocation loc)
       : builder_(std::move(status), loc) {}
 
-  StatusAdaptorForMacros(const StatusBuilder& builder, SourceLocation loc)
+  StatusAdaptorForMacros(const StatusBuilder& builder, SourceLocation)
       : builder_(builder) {}
 
-  StatusAdaptorForMacros(StatusBuilder&& builder, SourceLocation loc)
+  StatusAdaptorForMacros(StatusBuilder&& builder, SourceLocation)
       : builder_(std::move(builder)) {}
 
   StatusAdaptorForMacros(const StatusAdaptorForMacros&) = delete;

--- a/file_based_test_driver/base/unified_diff_oss.cc
+++ b/file_based_test_driver/base/unified_diff_oss.cc
@@ -35,7 +35,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/base/diffchunk.h"
 #include "file_based_test_driver/base/rediff.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 
 namespace file_based_test_driver_base {
 

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -469,7 +469,7 @@ static void BreakStringIntoAlternationsImpl(
         alternation_values_and_expanded_inputs,
     const std::string& selected_alternation_values) {
   // Identify one alternation group surrounded by "{{ }}".
-  absl::string_view alternation_group_match[3];
+  re2::StringPiece alternation_group_match[3];
   absl::string_view input_sp(input);
   // If alternation is not found, add input to output.
   if (!alternation_group_matcher->Match(
@@ -482,14 +482,14 @@ static void BreakStringIntoAlternationsImpl(
   // Identify values in alternation. alternation_group_match[2] is the submatch
   // that has the contents of the {{}}.
   const std::vector<std::string> alternation_values =
-      absl::StrSplit(alternation_group_match[2], '|', absl::AllowEmpty());
+      absl::StrSplit(alternation_group_match[2].data(), '|', absl::AllowEmpty());
 
   // For each alternation value, replace the first alternation group in <input>
   // with that value and recurse to expand the next alternation in <input>.
   for (const std::string& alternation_value : alternation_values) {
     // Replaces the 1st occurrence of alternation_group_match[1] => "{{...}}"".
     const std::string substituted_input =
-        StringReplace(input, alternation_group_match[1], alternation_value);
+        StringReplace(input, alternation_group_match[1].data(), alternation_value);
 
     // Recurse for expanding additional alternation groups.
     if (selected_alternation_values.empty()) {

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -197,17 +197,16 @@
 #include "absl/strings/string_view.h"
 #include "file_based_test_driver/run_test_case_result.h"
 
-// Set this flag to a positive value to force each test case to start with a
-// particular number of blank lines.
-ABSL_DECLARE_FLAG(int32_t, file_based_test_driver_insert_leading_blank_lines);
-
-// Set this flag to replace all substrings matching this pattern with a fixed
-// string on a copy of the expected output and generated output for diffing.
-ABSL_DECLARE_FLAG(std::string, file_based_test_driver_ignore_regex);
-
-// Set this flag to enable calling EXPECT_EQ on every diff. This enables
-// displaying individual diff failures in sponge.
-ABSL_DECLARE_FLAG(bool, file_based_test_driver_individual_tests);
+// Firebolt Start
+//
+// We are only exposing one custom flags here to minimize the risk of
+// shooting yourself in the foot:
+//
+// write_actual_result_files (default true)
+//    For tests that fail in the <testfile>, we write the actual result
+//    into a file called <testfile>_actual.
+ABSL_DECLARE_FLAG(bool, fb_write_actual);
+// Firebolt End
 
 namespace file_based_test_driver {
 

--- a/file_based_test_driver/test_case_mode.cc
+++ b/file_based_test_driver/test_case_mode.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/status_macros.h"
 
 namespace file_based_test_driver {
@@ -40,13 +40,13 @@ file_based_test_driver_base::StatusOr<TestCaseMode> TestCaseMode::Create(
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain empty strings";
     }
-    static LazyRE2 whitespace = {"\\s"};
-    if (RE2::PartialMatch(part, *whitespace)) {
+    static re2_st::LazyRE2 whitespace = {"\\s"};
+    if (re2_st::RE2::PartialMatch(part, *whitespace)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain spaces";
     }
-    static LazyRE2 literal_star = {"\\*"};
-    if (RE2::PartialMatch(part, *literal_star)) {
+    static re2_st::LazyRE2 literal_star = {"\\*"};
+    if (re2_st::RE2::PartialMatch(part, *literal_star)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain literal stars (*)";
     }

--- a/file_based_test_driver/test_case_options.h
+++ b/file_based_test_driver/test_case_options.h
@@ -132,26 +132,26 @@ struct TestCaseOption {
     kDuration,
   };
 
-  TestCaseOption(absl::string_view keyword, bool bool_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, bool bool_value)
+      : keyword(keyword_),
         type(kBool),
         default_value(bool_value),
         current_value(bool_value) {}
 
-  TestCaseOption(absl::string_view keyword, const std::string& str)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, const std::string& str)
+      : keyword(keyword_),
         type(kString),
         default_value(str),
         current_value(str) {}
 
-  TestCaseOption(absl::string_view keyword, int64_t int_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, int64_t int_value)
+      : keyword(keyword_),
         type(kInt64),
         default_value(int_value),
         current_value(int_value) {}
 
-  TestCaseOption(absl::string_view keyword, absl::Duration duration_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, absl::Duration duration_value)
+      : keyword(keyword_),
         type(kDuration),
         default_value(duration_value),
         current_value(duration_value) {}

--- a/file_based_test_driver/test_case_outputs.cc
+++ b/file_based_test_driver/test_case_outputs.cc
@@ -33,7 +33,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/test_case_mode.h"
 #include "file_based_test_driver/base/map_util.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 #include "file_based_test_driver/base/status_macros.h"
 
@@ -93,7 +93,7 @@ absl::Status ParseFirstLine(const absl::string_view part,
   } else {
     result->is_possible_modes = false;
     // TODO: Support [\n{}<>] in alternation modes with escaping.
-    if (!RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
+    if (!re2_st::RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
                         &result->result_type, &test_modes_sp)) {
       return absl::OkStatus();
     }

--- a/file_based_test_driver/test_case_outputs.cc
+++ b/file_based_test_driver/test_case_outputs.cc
@@ -86,7 +86,7 @@ absl::Status ParseFirstLine(const absl::string_view part,
 
   absl::string_view stripped_first_line = result->first_line;
   stripped_first_line = absl::StripLeadingAsciiWhitespace(stripped_first_line);
-  absl::string_view test_modes_sp;
+  std::string test_modes_sp;
   if (absl::ConsumePrefix(&stripped_first_line, kPossibleModesPrefix)) {
     result->is_possible_modes = true;
     test_modes_sp = stripped_first_line;


### PR DESCRIPTION
 Improve Ease of Use for Wrong Results

At the moment, the file-based test driver has a few problems:
  - It dumps a crazy amount of text to stdout, even if everything goes right.
  - It does not make it very easy to see what exactly failed. This is especially true for long text files with many test cases.

This PR is a rather hacky approach to solve our biggest problems with this:
  - We still write extensive logs into /tmp/file_based_test_driver.
  - We only dump things to stdout when tests fail. In that case we write out both the expected result, as well as the actual one.
  - If a test fails, we create a <textfile>_actual file containing context on the failed tests, as well as the exact diff.
