### PR TITLE
feat(FIR-25191): output_has_header option for better comparison with unsorted_output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+Language:        Cpp
+BasedOnStyle:  Google
+---
+Language: Proto
+BasedOnStyle: Google

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 ## File Based Test Driver
 
-## Build
-
-File Based Test Driver uses [bazel](https://bazel.build) for building and
-dependency resolution. After installing bazel (we maintain support for 1.0,
-but other versions may work), simply run:
-
-```bazel build ...```
-
 ## Overview
 
 file_based_test_driver
@@ -15,13 +7,13 @@ uses `.test` files to specify sets of inputs and expected outputs. The format
 of these files is documented in `file_based_test_driver.h`.
 
 A detailed example that shows all features is in
-[`example.test`](example.test) and the associated test driver
-[`example_test.cc`](example_test.cc).
+[`example.test`](file_based_test_driver/example.test) and the associated test driver
+[`example_test.cc`](file_based_test_driver/example_test.cc).
 
 #### Test output with modes
 
 file_based_test_driver's basic test runner
-[RunTestCasesFromFiles](file_based_test_driver.h)
+[RunTestCasesFromFiles](file_based_test_driver/file_based_test_driver.h)
 calls a callback to run a test, gets back the actual outputs, and does string
 comparison on the actual and expected outputs. In some cases, the test callback
 may run a test case multiple times in different modes and each mode may generate
@@ -35,10 +27,10 @@ that understands test modes. The format of the test file is very similar to the
 one that is used with the basic test runner. Each test still has an input block
 followed by multiple output blocks. The only difference is that the output
 blocks of a test must be parsable by
-[`test_case_outputs.h`](test_case_outputs.h).
+[`test_case_outputs.h`](file_based_test_driver/test_case_outputs.h).
 The text format of such test output and its internal representation is
 documented in
-[`test_case_outputs.h`](test_case_outputs.h).
+[`test_case_outputs.h`](file_based_test_driver/test_case_outputs.h).
 The new test runner will first parse the expected output and group the outputs
 by test modes. It then calls the test callback and gets back the actual outputs
 for one or more modes, merges them into the expected outputs (only the outputs
@@ -46,10 +38,10 @@ for the modes tested are replaced), and compares the merged results with the
 expected results.
 
 Example that shows the test mode related features is in
-[`example_with_modes.test`](example_with_modes.test)
+[`example_with_modes.test`](file_based_test_driver/example_with_modes.test)
 and
 the associated test driver
-[`example_test_with_modes.cc`](example_test_with_modes.cc).
+[`example_test_with_modes.cc`](file_based_test_driver/example_test_with_modes.cc).
 
 ## Contributions
 

--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -18,6 +18,7 @@
 #include "absl/strings/str_join.h"
 #include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
+#include "file_based_test_driver/file_based_test_driver.h"
 
 namespace file_based_test_driver {
 
@@ -27,8 +28,16 @@ const char AlternationSetWithModes::kEmptyAlternationName[] = "EMPTY";
 absl::Status AlternationSet::Record(const std::string& alternation_name,
                                     const RunTestCaseResult& test_case_result) {
   FILE_BASED_TEST_DRIVER_RET_CHECK(!finished_);
-  alternation_map_[test_case_result.test_outputs()].push_back(
-      alternation_names_.size());
+  // Firebolt Start
+  std::vector<std::string> test_outputs = test_case_result.test_outputs();
+  if (test_case_result.compare_unsorted_result()) {
+    // test_outputs.size() > 1 if there are multiple outputs per alternation.
+    for (std::string& output : test_outputs) {
+      output = SortLines(output);
+    }
+  }
+  alternation_map_[test_outputs].push_back(alternation_names_.size());
+  // Firebolt End
   alternation_names_.push_back(alternation_name.empty() ? kEmptyAlternationName
                                                         : alternation_name);
   return absl::OkStatus();

--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -33,7 +33,7 @@ absl::Status AlternationSet::Record(const std::string& alternation_name,
   if (test_case_result.compare_unsorted_result()) {
     // test_outputs.size() > 1 if there are multiple outputs per alternation.
     for (std::string& output : test_outputs) {
-      output = SortLines(output);
+      output = SortLines(output, test_case_result.output_has_header());
     }
   }
   alternation_map_[test_outputs].push_back(alternation_names_.size());

--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -16,7 +16,7 @@
 #include "file_based_test_driver/alternations.h"
 
 #include "absl/strings/str_join.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 
 namespace file_based_test_driver {
@@ -102,8 +102,8 @@ absl::Status AlternationSetWithModes::Record(
     const std::string& alternation_name,
     const RunTestCaseWithModesResult& test_case_result) {
   FILE_BASED_TEST_DRIVER_RET_CHECK(!finished_);
-  static LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
-  FILE_BASED_TEST_DRIVER_RET_CHECK(!RE2::PartialMatch(alternation_name, *re))
+  static re2_st::LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
+  FILE_BASED_TEST_DRIVER_RET_CHECK(!re2_st::RE2::PartialMatch(alternation_name, *re))
       << "Alternation \"" << alternation_name << "\" contains names that can't "
       << "be stored in a result_type: " << re->pattern();
   alternations_.emplace_back(

--- a/file_based_test_driver/base/logging.cc
+++ b/file_based_test_driver/base/logging.cc
@@ -253,8 +253,6 @@ void LogMessage::SendToLog(const std::string &message_text) {
     fprintf(stderr, "%s\n", message_text.c_str());
     fflush(stderr);
   }
-  printf("%s\n", message_text.c_str());
-  fflush(stdout);
 }
 
 void LogMessage::Flush() {

--- a/file_based_test_driver/base/source_location.h
+++ b/file_based_test_driver/base/source_location.h
@@ -133,7 +133,6 @@ class SourceLocation {
   std::uint_least32_t line_;
   std::uint_least32_t unused_column_ = 0;
   const char* file_name_;
-  const char* unused_function_name_ = nullptr;
 };
 
 }  // namespace file_based_test_driver_base

--- a/file_based_test_driver/base/status_macros.h
+++ b/file_based_test_driver/base/status_macros.h
@@ -189,10 +189,10 @@ class StatusAdaptorForMacros {
   StatusAdaptorForMacros(absl::Status&& status, SourceLocation loc)
       : builder_(std::move(status), loc) {}
 
-  StatusAdaptorForMacros(const StatusBuilder& builder, SourceLocation loc)
+  StatusAdaptorForMacros(const StatusBuilder& builder, SourceLocation)
       : builder_(builder) {}
 
-  StatusAdaptorForMacros(StatusBuilder&& builder, SourceLocation loc)
+  StatusAdaptorForMacros(StatusBuilder&& builder, SourceLocation)
       : builder_(std::move(builder)) {}
 
   StatusAdaptorForMacros(const StatusAdaptorForMacros&) = delete;

--- a/file_based_test_driver/base/unified_diff_oss.cc
+++ b/file_based_test_driver/base/unified_diff_oss.cc
@@ -35,7 +35,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/base/diffchunk.h"
 #include "file_based_test_driver/base/rediff.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 
 namespace file_based_test_driver_base {
 

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -385,17 +385,17 @@ static bool CompareAndAppendOutput(
 
     // Write results to the file.
     actual.open(std::string(filename) + "_actual", mode);
+    if (!all_output->empty()) {
+      actual << "==\n";
+    }
+    actual << output_string;
+    actual.close();
   }
   // Firebolt End
 
   // Add to all_output.
   if (!all_output->empty()) {
     absl::StrAppend(all_output, "==\n");
-    // Firebolt Start
-    if (absl::GetFlag(FLAGS_fb_write_actual)) {
-      actual << "==\n";
-    }
-    // Firebolt End
   }
   if (matches_requested_same_as_previous) {
     absl::StrAppend(all_output,
@@ -404,12 +404,6 @@ static bool CompareAndAppendOutput(
   } else {
     absl::StrAppend(all_output, output_string);
   }
-  // Firebolt Start
-  if (absl::GetFlag(FLAGS_fb_write_actual)) {
-    actual << output_string;
-    actual.close();
-  }
-  // Firebolt End
 
   return found_diffs;
 }

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -324,19 +324,8 @@ static bool CompareAndAppendOutput(
       if (is_alternation_group_descr) {
         continue;
       }
-
-      const auto sort_lines = [](std::string_view part) {
-        // Exclude lines with only whitespace, as they lead to undesired results
-        // after sorting when calling BuildTestFileEntry.
-        std::vector<std::string> lines =
-            absl::StrSplit(part, "\n", absl::SkipWhitespace());
-        std::sort(lines.begin(), lines.end());
-        std::string sorted_part = absl::StrJoin(lines, "\n");
-        sorted_part.push_back('\n');
-        return sorted_part;
-      };
-      sorted_expected_parts[i] = sort_lines(sorted_expected_parts[i]);
-      sorted_output_parts[i] = sort_lines(sorted_output_parts[i]);
+      sorted_expected_parts[i] = SortLines(sorted_expected_parts[i]);
+      sorted_output_parts[i] = SortLines(sorted_output_parts[i]);
     }
 
     const std::string sorted_output_string =
@@ -1222,6 +1211,24 @@ bool RunTestCasesWithModesFromFiles(
                                RunTestCaseWithModesOutput>(
       filespec, wrapped_run_test_case);
 }
+
+// Firebolt Start
+std::string SortLines(absl::string_view s) {
+  const bool ends_with_nl = !s.empty() && s.back() == '\n';
+  if (ends_with_nl) {
+    // Remove the final newline char to avoid that StrSplit adds an empty string
+    // to lines.
+    s.remove_suffix(1);
+  }
+  std::vector<std::string> lines = absl::StrSplit(s, "\n");
+  std::sort(lines.begin(), lines.end());
+  std::string sorted_lines = absl::StrJoin(lines, "\n");
+  if (ends_with_nl) {
+    sorted_lines.push_back('\n');
+  }
+  return sorted_lines;
+}
+// Firebolt End
 
 int64_t CountTestCasesInFiles(absl::string_view filespec) {
   std::vector<std::string> test_files;

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -72,7 +72,7 @@ ABSL_FLAG(int32_t, file_based_test_driver_stack_size_kb, 64,
 // Firebolt Start
 ABSL_FLAG(bool, fb_write_actual, true,
           "If true, a test failing in <testfile> will generate the actual"
-          "will generate the actual test result in <testfile>_actual.");
+          "test result in <testfile>_actual.");
 // Firebolt End
 
 namespace {

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -394,9 +394,7 @@ static bool CompareAndAppendOutput(
   // Firebolt End
 
   // Add to all_output.
-  if (!all_output->empty()) {
-    absl::StrAppend(all_output, "==\n");
-  }
+  if (!all_output->empty()) absl::StrAppend(all_output, "==\n");
   if (matches_requested_same_as_previous) {
     absl::StrAppend(all_output,
                     internal::BuildTestFileEntry(

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -469,7 +469,7 @@ static void BreakStringIntoAlternationsImpl(
         alternation_values_and_expanded_inputs,
     const std::string& selected_alternation_values) {
   // Identify one alternation group surrounded by "{{ }}".
-  absl::string_view alternation_group_match[3];
+  re2::StringPiece alternation_group_match[3];
   absl::string_view input_sp(input);
   // If alternation is not found, add input to output.
   if (!alternation_group_matcher->Match(
@@ -482,14 +482,14 @@ static void BreakStringIntoAlternationsImpl(
   // Identify values in alternation. alternation_group_match[2] is the submatch
   // that has the contents of the {{}}.
   const std::vector<std::string> alternation_values =
-      absl::StrSplit(alternation_group_match[2], '|', absl::AllowEmpty());
+      absl::StrSplit(alternation_group_match[2].data(), '|', absl::AllowEmpty());
 
   // For each alternation value, replace the first alternation group in <input>
   // with that value and recurse to expand the next alternation in <input>.
   for (const std::string& alternation_value : alternation_values) {
     // Replaces the 1st occurrence of alternation_group_match[1] => "{{...}}"".
     const std::string substituted_input =
-        StringReplace(input, alternation_group_match[1], alternation_value);
+        StringReplace(input, alternation_group_match[1].data(), alternation_value);
 
     // Recurse for expanding additional alternation groups.
     if (selected_alternation_values.empty()) {

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -292,7 +292,7 @@ int64_t CountTestCasesInFiles(absl::string_view filespec);
 
 // Firebolt Start
 // Returns a string with all the lines in s sorted lexicographically.
-std::string SortLines(absl::string_view s);
+std::string SortLines(absl::string_view s, bool skip_header);
 // Firebolt End
 
 // Internal functions. Exposed here for unit testing purposes only, do not use

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -290,6 +290,11 @@ ABSL_MUST_USE_RESULT bool RunTestCasesWithModesFromFiles(
 // RunTestCaseFromFiles(filespec, run_test_case) were called.
 int64_t CountTestCasesInFiles(absl::string_view filespec);
 
+// Firebolt Start
+// Returns a string with all the lines in s sorted lexicographically.
+std::string SortLines(absl::string_view s);
+// Firebolt End
+
 // Internal functions. Exposed here for unit testing purposes only, do not use
 // directly.
 namespace internal {

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -199,8 +199,8 @@
 
 // Firebolt Start
 //
-// We are only exposing one custom flags here to minimize the risk of
-// shooting yourself in the foot:
+// We are only exposing one custom flag here to minimize the risk of
+// shooting ourselves in the foot:
 //
 // write_actual_result_files (default true)
 //    For tests that fail in the <testfile>, we write the actual result

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -197,17 +197,16 @@
 #include "absl/strings/string_view.h"
 #include "file_based_test_driver/run_test_case_result.h"
 
-// Set this flag to a positive value to force each test case to start with a
-// particular number of blank lines.
-ABSL_DECLARE_FLAG(int32_t, file_based_test_driver_insert_leading_blank_lines);
-
-// Set this flag to replace all substrings matching this pattern with a fixed
-// string on a copy of the expected output and generated output for diffing.
-ABSL_DECLARE_FLAG(std::string, file_based_test_driver_ignore_regex);
-
-// Set this flag to enable calling EXPECT_EQ on every diff. This enables
-// displaying individual diff failures in sponge.
-ABSL_DECLARE_FLAG(bool, file_based_test_driver_individual_tests);
+// Firebolt Start
+//
+// We are only exposing one custom flags here to minimize the risk of
+// shooting yourself in the foot:
+//
+// write_actual_result_files (default true)
+//    For tests that fail in the <testfile>, we write the actual result
+//    into a file called <testfile>_actual.
+ABSL_DECLARE_FLAG(bool, fb_write_actual);
+// Firebolt End
 
 namespace file_based_test_driver {
 

--- a/file_based_test_driver/file_based_test_driver_test.cc
+++ b/file_based_test_driver/file_based_test_driver_test.cc
@@ -133,6 +133,12 @@ void VerifyGetNextTestdata(
   }
 }
 
+TEST(TestdataUtilTest, SortLines) {
+  EXPECT_EQ("a\nb\nc", SortLines("b\na\nc"));
+  EXPECT_EQ("1\n2\n3\n", SortLines("2\n3\n1\n"));
+  EXPECT_EQ("aba\nabb\nabc\n", SortLines("abb\naba\nabc\n"));
+}
+
 TEST(TestdataUtilTest, Basic) {
   VerifyGetNextTestdata(
       "Part 1\n"
@@ -573,6 +579,10 @@ static void RunTestCompareUnsortedResultCallback(
     test_result->AddTestOutput("Pas\nTob\nBen\nLeo\nLor\n");
   } else if (test_case == "Test 3\n") {
     test_result->AddTestOutput("42\n43\n44\n");
+  } else if (test_case == "Test 4\n") {
+    test_result->AddTestOutput("2\n1\n3\n");
+  } else if (test_case == "Test 5\n") {
+    test_result->AddTestOutput("3\n1\n2\n");
   }
 }
 
@@ -601,6 +611,12 @@ ALTERNATION GROUP: 3
 44
 42
 43
+==
+Test {{4|5}}
+--
+1
+2
+3
 )";
 
   internal::RegisteredTempFile test_file("testdata_util_test.test",

--- a/file_based_test_driver/run_test_case_result.h
+++ b/file_based_test_driver/run_test_case_result.h
@@ -81,6 +81,11 @@ class RunTestCaseResultBase {
   void set_compare_unsorted_result(bool compare_unsorted_result) {
     compare_unsorted_result_ = compare_unsorted_result;
   }
+
+  bool output_has_header() const { return output_has_header_; }
+  void set_output_has_header(bool output_has_header) {
+    output_has_header_ = output_has_header;
+  }
   // Firebolt End
 
  private:
@@ -102,6 +107,9 @@ class RunTestCaseResultBase {
   // result even if the order of the lines is different. Currently, this is
   // achieved by lexicographically sorting the lines before comparison.
   bool compare_unsorted_result_{false};
+  // If compare_unsorted_result_ is true, decide whether first line of the
+  // result is a header, and hence doesn't need to be sorted
+  bool output_has_header_{false};
   // Firebolt End
 };
 

--- a/file_based_test_driver/run_test_case_result.h
+++ b/file_based_test_driver/run_test_case_result.h
@@ -76,6 +76,11 @@ class RunTestCaseResultBase {
   void set_expected_output_is_regex(bool expected_output_is_regex) {
     expected_output_is_regex_ = expected_output_is_regex;
   }
+
+  bool compare_unsorted_result() const { return compare_unsorted_result_; }
+  void set_compare_unsorted_result(bool compare_unsorted_result) {
+    compare_unsorted_result_ = compare_unsorted_result;
+  }
   // Firebolt End
 
  private:
@@ -93,6 +98,10 @@ class RunTestCaseResultBase {
   // that must match the entire actual output. Otherwise, the expected output
   // must match the actual output literally.
   bool expected_output_is_regex_{false};
+  // If compare_unsorted_result_ is true, the actual result matches the expected
+  // result even if the order of the lines is different. Currently, this is
+  // achieved by lexicographically sorting the lines before comparison.
+  bool compare_unsorted_result_{false};
   // Firebolt End
 };
 

--- a/file_based_test_driver/run_test_case_result.h
+++ b/file_based_test_driver/run_test_case_result.h
@@ -71,6 +71,13 @@ class RunTestCaseResultBase {
   // Returns true if output has been added for the given test case.
   virtual bool IsEmpty() const = 0;
 
+  // Firebolt Start
+  bool expected_output_is_regex() const { return expected_output_is_regex_; }
+  void set_expected_output_is_regex(bool expected_output_is_regex) {
+    expected_output_is_regex_ = expected_output_is_regex;
+  }
+  // Firebolt End
+
  private:
   // If set to true, indicates that the test was intentionally skipped.
   // In this case, the test driver will pretend that the test returned exactly
@@ -81,6 +88,12 @@ class RunTestCaseResultBase {
   int line_ = 0;
   std::vector<std::string> parts_;
   std::string test_alternation_;
+  // Firebolt Start
+  // If expected_output_is_regex_ is true, treat the expected output as a regex
+  // that must match the entire actual output. Otherwise, the expected output
+  // must match the actual output literally.
+  bool expected_output_is_regex_{false};
+  // Firebolt End
 };
 
 // The result of a test case run without Modes support. Output should be added

--- a/file_based_test_driver/test_case_mode.cc
+++ b/file_based_test_driver/test_case_mode.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/status_macros.h"
 
 namespace file_based_test_driver {
@@ -40,13 +40,13 @@ file_based_test_driver_base::StatusOr<TestCaseMode> TestCaseMode::Create(
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain empty strings";
     }
-    static LazyRE2 whitespace = {"\\s"};
-    if (RE2::PartialMatch(part, *whitespace)) {
+    static re2_st::LazyRE2 whitespace = {"\\s"};
+    if (re2_st::RE2::PartialMatch(part, *whitespace)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain spaces";
     }
-    static LazyRE2 literal_star = {"\\*"};
-    if (RE2::PartialMatch(part, *literal_star)) {
+    static re2_st::LazyRE2 literal_star = {"\\*"};
+    if (re2_st::RE2::PartialMatch(part, *literal_star)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain literal stars (*)";
     }

--- a/file_based_test_driver/test_case_options.h
+++ b/file_based_test_driver/test_case_options.h
@@ -132,26 +132,26 @@ struct TestCaseOption {
     kDuration,
   };
 
-  TestCaseOption(absl::string_view keyword, bool bool_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, bool bool_value)
+      : keyword(keyword_),
         type(kBool),
         default_value(bool_value),
         current_value(bool_value) {}
 
-  TestCaseOption(absl::string_view keyword, const std::string& str)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, const std::string& str)
+      : keyword(keyword_),
         type(kString),
         default_value(str),
         current_value(str) {}
 
-  TestCaseOption(absl::string_view keyword, int64_t int_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, int64_t int_value)
+      : keyword(keyword_),
         type(kInt64),
         default_value(int_value),
         current_value(int_value) {}
 
-  TestCaseOption(absl::string_view keyword, absl::Duration duration_value)
-      : keyword(keyword),
+  TestCaseOption(absl::string_view keyword_, absl::Duration duration_value)
+      : keyword(keyword_),
         type(kDuration),
         default_value(duration_value),
         current_value(duration_value) {}

--- a/file_based_test_driver/test_case_outputs.cc
+++ b/file_based_test_driver/test_case_outputs.cc
@@ -33,7 +33,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/test_case_mode.h"
 #include "file_based_test_driver/base/map_util.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 #include "file_based_test_driver/base/status_macros.h"
 
@@ -93,7 +93,7 @@ absl::Status ParseFirstLine(const absl::string_view part,
   } else {
     result->is_possible_modes = false;
     // TODO: Support [\n{}<>] in alternation modes with escaping.
-    if (!RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
+    if (!re2_st::RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
                         &result->result_type, &test_modes_sp)) {
       return absl::OkStatus();
     }

--- a/file_based_test_driver/test_case_outputs.cc
+++ b/file_based_test_driver/test_case_outputs.cc
@@ -86,7 +86,7 @@ absl::Status ParseFirstLine(const absl::string_view part,
 
   absl::string_view stripped_first_line = result->first_line;
   stripped_first_line = absl::StripLeadingAsciiWhitespace(stripped_first_line);
-  absl::string_view test_modes_sp;
+  std::string test_modes_sp;
   if (absl::ConsumePrefix(&stripped_first_line, kPossibleModesPrefix)) {
     result->is_possible_modes = true;
     test_modes_sp = stripped_first_line;


### PR DESCRIPTION
## Summary
We use `[unsorted_output]` to compare results of queries which produce multiple rows, e.g. in `sql_test`

```
[unsorted_output]
select * from unnest([1,5,2] x) 
--
x INTEGER
1
5
2
```

The problem is that since `[unsorted_output]` just sorts all the lines in the output, the header row which is produced by `TestTextOutput` formatter ends up at the end:

```
1
2
5
x INTEGER
```

which is really inconvinient. So we add an option (which will be automatically triggered by sql_test for `TestTextOutput` and other formats with header row) - called `output_has_header`, which tells file based driver not to sort the first row, so the result will end up being:

```
x INTEGER
1
2
5
```

## Test
I couldn't get `bazel` working on file-based-test-driver - so all the testing was done using `sql_test`, which will be visible in the followup PR to packdb.